### PR TITLE
fix: use edge runtime for api functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/**/*.ts": {
-      "runtime": "nodejs18.x"
+      "runtime": "edge"
     }
   },
   "env": {


### PR DESCRIPTION
## Summary
- Ensure Vercel functions use Edge runtime to match API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, empty block statements, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a7f57f8208321b264dbe31f7adf7c