### PR TITLE
fix: use edge runtime for api functions

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,4 @@
 {
-  "functions": {
-    "api/**/*.ts": {
-      "runtime": "nodejs18.x"
-    }
-  },
   "env": {
     "VITE_USE_PROXY": "true"
   },


### PR DESCRIPTION
## Summary
- remove invalid functions runtime config to rely on Edge runtime declared in API routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, empty block statements, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689a7f57f8208321b264dbe31f7adf7c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to use the platform’s default runtime for API routes, removing an explicit runtime constraint.
  * No user-facing changes expected; existing functionality should continue to work as before.
  * Minor formatting improvement to configuration file (added end-of-file newline).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->